### PR TITLE
fix: Fix the example of the parameter `clone_options`

### DIFF
--- a/src/commands/checkout_shallow.yml
+++ b/src/commands/checkout_shallow.yml
@@ -17,7 +17,7 @@ parameters:
     type: string
     default: ""
     description: >
-      git clone options you want to add. like `options: '--shallow-since "5 days ago" --verbose'
+      git clone options you want to add such as '--depth 1 --verbose' and '--shallow-since "5 days ago"'
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.


### PR DESCRIPTION
🙇 Sorry but I missed.

* https://github.com/guitarrapc/git-shallow-clone-orb/commit/4ba2a2c486376970cc2cf75657553fa76b41a1ca
* https://github.com/guitarrapc/git-shallow-clone-orb/pull/10#discussion_r395996007

I intended `--depth 1 --verbose` but actually `--shallow-since "5 days ago" --verbose`.