### PR TITLE
Allow for PRs from API call; that have /head or /merge suffixes

### DIFF
--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -81,7 +81,7 @@ steps:
         then
           # tag
           git fetch -t --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
-        elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
+        elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request
           git fetch --depth << parameters.fetch_depth >> --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"


### PR DESCRIPTION
If a user launches a CircleCI pipeline using the API, the `$CIRCLE_BRANCH` variable is already populated with a `/head` or `/merge` suffix (e.g. `pull/895/head`) - this will cause the shallow checkout to fail.

Use a modified regex such that, if the suffix is already present, we fall through to the third case, where the suffix `/head` is not added.
