### PR TITLE
Add tag_fetch_options to advanced checkout

### DIFF
--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -80,7 +80,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch -t --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
+          git fetch --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -80,7 +80,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch -t --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
+          git fetch --tags --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -80,7 +80,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+          git fetch -t --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -13,6 +13,7 @@ parameters:
     description: >
       git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
       you donot beed set '--force' option as it already set by default.
+      in case of tag, '-t' sat by default in tag_fetch_options
   tag_fetch_options:
     type: string
     default: "--tags"

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -19,7 +19,7 @@ parameters:
     default: "--tags"
     description: >
       Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'.
-      Default value is -t
+      Default value is --tags
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -15,9 +15,9 @@ parameters:
       you donot beed set '--force' option as it already set by default.
   tag_fetch_options:
     type: string
-    default: "-t"
+    default: "--tags"
     description: >
-      Additional git fetch options you want to add specifically for tags such as '-t' or '--no-tags'.
+      Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'.
       Default value is -t
   keyscan_github:
     description: >

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -13,6 +13,12 @@ parameters:
     description: >
       git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
       you donot beed set '--force' option as it already set by default.
+  tag_fetch_options:
+    type: string
+    default: "-t"
+    description: >
+      Additional git fetch options you want to add specifically for tags such as '-t' or '--no-tags'.
+      Default value is -t
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.
@@ -81,7 +87,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch << parameters.fetch_options >> --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+          git fetch << parameters.tag_fetch_options >> << parameters.fetch_options >> --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
         then
           # pull request

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -13,7 +13,6 @@ parameters:
     description: >
       git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
       you donot beed set '--force' option as it already set by default.
-      in case of tag, '-t' sat by default either.
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.
@@ -82,7 +81,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch -t << parameters.fetch_options >> --force origin "refs/tags/${CIRCLE_TAG}"
+          git fetch << parameters.fetch_options >> --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
         then
           # pull request


### PR DESCRIPTION
This orb currently fetches **all** tags when run from a tag. This can be problematic when a repo has many tags. For example, we have a repo with almost 3000 tags and the checkout process takes around 3 minutes on a tagged build in CI.


This PR adds `tag_fetch_options` to `advanced_checkout`.
  - used in addition to `fetch_options` when fetching tags
  - defaults to `--tags` to avoid backwards-compatibility issues
  - can be used to pass in `--no-tags`, overriding default `--tags` behavior