### PR TITLE
feat: add no_tags to git-shallow-clone/checkout, add test and examples.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,11 @@ jobs:
           clone_options: "--depth 1"
           fetch_options: "--depth 1000 --no-tags"
           tag_fetch_options: "--no-tags"
-      - run: git tag --list # should be no tags
+      # should be no tags
+      - run: |
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ count -ne 0 ]; then exit 1; fi
   integration-test-checkout_advanced_tags:
     docker:
       - image: cimg/base:stable
@@ -54,7 +58,11 @@ jobs:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1"
           fetch_options: "--depth 1000"
-      - run: git tag --list # should be all tags in fetch depth
+      # should be all tags in fetch depth
+      - run: |
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ count -eq 0 ]; then exit 1; fi
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
@@ -98,7 +106,11 @@ jobs:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
           no_tags: true
-      - run: git tag --list # should be no tags
+      # should be no tags
+      - run: |
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ count -ne 0 ]; then exit 1; fi
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable
@@ -111,7 +123,11 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
-      - run: git tag --list # should be all tags in fetch depth
+      # should be all tags in fetch depth
+      - run: |
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ count -eq 0 ]; then exit 1; fi
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,10 @@ jobs:
           tag_fetch_options: "--no-tags"
       # should be no tags
       - run: |
+          set -e
           git tag --list
           count=$(git tag --list | wc -l)
-          if [ count -ne 0 ]; then exit 1; fi
+          if [ $count -ne 0 ]; then exit 1; fi
   integration-test-checkout_advanced_tags:
     docker:
       - image: cimg/base:stable
@@ -60,9 +61,10 @@ jobs:
           fetch_options: "--depth 1000"
       # should be all tags in fetch depth
       - run: |
+          set -e
           git tag --list
           count=$(git tag --list | wc -l)
-          if [ count -eq 0 ]; then exit 1; fi
+          if [ $count -eq 0 ]; then exit 1; fi
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
@@ -108,9 +110,10 @@ jobs:
           no_tags: true
       # should be no tags
       - run: |
+          set -e
           git tag --list
           count=$(git tag --list | wc -l)
-          if [ count -ne 0 ]; then exit 1; fi
+          if [ $count -ne 0 ]; then exit 1; fi
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable
@@ -125,9 +128,10 @@ jobs:
           fetch_depth: 1000
       # should be all tags in fetch depth
       - run: |
+          set -e
           git tag --list
           count=$(git tag --list | wc -l)
-          if [ count -eq 0 ]; then exit 1; fi
+          if [ $count -eq 0 ]; then exit 1; fi
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,23 +26,32 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout
+      - run: git tag
   integration-test-checkout_advanced:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced
+      - run: git tag
+  integration-test-checkout_advanced_fetchoptions:
     docker:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--shallow-since "5 days ago"'
           fetch_options: '--shallow-since "5 days ago"'
+  integration-test-checkout_advanced_notags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          tag_fetch_options: --no-tags
+      - run: git tag
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
     steps:
       - run: apk update && apk add openssh git # openssh is required
-      - git-shallow-clone/checkout
-  integration-test-checkout_macos:
-    macos:
-      xcode: 13.0.0
-    steps:
       - git-shallow-clone/checkout
   integration-test-checkout_depth:
     docker:
@@ -69,6 +78,11 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           keyscan_github: true
+  integration-test-checkout_macos:
+    macos:
+      xcode: 13.0.0
+    steps:
+      - git-shallow-clone/checkout
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable
@@ -107,12 +121,14 @@ workflows:
       # Run any integration tests defined within the `jobs` key.
       - integration-test-checkout
       - integration-test-checkout_advanced
+      - integration-test-checkout_advanced_fetchoptions
+      - integration-test-checkout_advanced_notags
       - integration-test-checkout_alpine
-      - integration-test-checkout_macos
       - integration-test-checkout_depth
       - integration-test-checkout_fetchdepth
       - integration-test-checkout_keyscan_bitbucket
       - integration-test-checkout_keyscan_github
+      - integration-test-checkout_macos
       - integration-test-checkout_path
 
       # Publish a semver version of the orb. relies on
@@ -129,12 +145,14 @@ workflows:
           requires:
             - integration-test-checkout
             - integration-test-checkout_advanced
+            - integration-test-checkout_advanced_fetchoptions
+            - integration-test-checkout_advanced_notags
             - integration-test-checkout_alpine
-            - integration-test-checkout_macos
             - integration-test-checkout_depth
             - integration-test-checkout_fetchdepth
             - integration-test-checkout_keyscan_bitbucket
             - integration-test-checkout_keyscan_github
+            - integration-test-checkout_macos
             - integration-test-checkout_path
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
-          #no_tags: true
+          no_tags: true
       - run: git tag --list # should be no tags
   integration-test-checkout_path:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1"
-          fetch_options: "--depth 1000"
+          fetch_options: "--depth 1000 --no-tags"
           tag_fetch_options: "--no-tags"
       - run: git tag --list
   integration-test-checkout_advanced_tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           clone_options: "--depth 1"
           fetch_options: "--depth 1000 --no-tags"
           tag_fetch_options: "--no-tags"
-      - run: git tag --list
+      - run: git tag --list # should be no tags
   integration-test-checkout_advanced_tags:
     docker:
       - image: cimg/base:stable
@@ -54,7 +54,7 @@ jobs:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1"
           fetch_options: "--depth 1000"
-      - run: git tag --list
+      - run: git tag --list # should be all tags in fetch depth
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
@@ -91,6 +91,14 @@ jobs:
       xcode: 13.0.0
     steps:
       - git-shallow-clone/checkout
+  integration-test-checkout_notags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          fetch_depth: 1000
+          without_tags: true
+      - run: git tag --list # should be not tags
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable
@@ -103,7 +111,7 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
-      - run: git tag --list
+      - run: git tag --list # should be all tags in fetch depth
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
@@ -145,6 +153,7 @@ workflows:
       - integration-test-checkout_keyscan_bitbucket
       - integration-test-checkout_keyscan_github
       - integration-test-checkout_macos
+      - integration-test-checkout_notags
       - integration-test-checkout_path
       - integration-test-checkout_tags
 
@@ -171,6 +180,7 @@ workflows:
             - integration-test-checkout_keyscan_bitbucket
             - integration-test-checkout_keyscan_github
             - integration-test-checkout_macos
+            - integration-test-checkout_notags
             - integration-test-checkout_path
             - integration-test-checkout_tags
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,11 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout
-      - run: git tag
   integration-test-checkout_advanced:
     docker:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout_advanced
-      - run: git tag
   integration-test-checkout_advanced_fetchoptions:
     docker:
       - image: cimg/base:stable
@@ -45,8 +43,18 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout_advanced:
-          tag_fetch_options: --no-tags
-      - run: git tag
+          clone_options: "--depth 1"
+          fetch_options: "--depth 1000"
+          tag_fetch_options: "--no-tags"
+      - run: git tag --list
+  integration-test-checkout_advanced_tags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: "--depth 1"
+          fetch_options: "--depth 1000"
+      - run: git tag --list
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
@@ -89,6 +97,13 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           path: src
+  integration-test-checkout_tags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          fetch_depth: 1000
+      - run: git tag --list
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
@@ -123,6 +138,7 @@ workflows:
       - integration-test-checkout_advanced
       - integration-test-checkout_advanced_fetchoptions
       - integration-test-checkout_advanced_notags
+      - integration-test-checkout_advanced_tags
       - integration-test-checkout_alpine
       - integration-test-checkout_depth
       - integration-test-checkout_fetchdepth
@@ -130,6 +146,7 @@ workflows:
       - integration-test-checkout_keyscan_github
       - integration-test-checkout_macos
       - integration-test-checkout_path
+      - integration-test-checkout_tags
 
       # Publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -147,6 +164,7 @@ workflows:
             - integration-test-checkout_advanced
             - integration-test-checkout_advanced_fetchoptions
             - integration-test-checkout_advanced_notags
+            - integration-test-checkout_advanced_tags
             - integration-test-checkout_alpine
             - integration-test-checkout_depth
             - integration-test-checkout_fetchdepth
@@ -154,6 +172,7 @@ workflows:
             - integration-test-checkout_keyscan_github
             - integration-test-checkout_macos
             - integration-test-checkout_path
+            - integration-test-checkout_tags
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
-          no_tags: true
+          #no_tags: true
       - run: git tag --list # should be no tags
   integration-test-checkout_path:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,8 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           fetch_depth: 1000
-          without_tags: true
-      - run: git tag --list # should be not tags
+          no_tags: true
+      - run: git tag --list # should be no tags
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -99,7 +99,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch ${tag_args} --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
+          git fetch ${tag_args} --depth << parameters.fetch_depth >> --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -8,10 +8,18 @@ parameters:
     default: 1
   fetch_depth:
     description: >
-      Addtional fetch depth fetch depth to the specified number of commit from a remote branch history.
+      Addtional fetch depth to the specified number of commit from a remote branch history.
       Pass more number then depth when you want to check futher commit history.
     type: integer
     default: 10
+  without_tags:
+    description: >
+      true to add '--no-tags' when fetching.
+      As git not offer tag depth, we only able to control fetch all tags or not.
+      This enable you to stop fetch tags when you have vast numbers of tags during specified fetch depth.
+      In other word, if you need tag then fetch specified tags manually when use 'without_tag: true'.
+    type: boolean
+    default: false
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.
@@ -76,18 +84,29 @@ steps:
         git clone --depth << parameters.depth >> $CIRCLE_REPOSITORY_URL "<< parameters.path >>"
         cd "<< parameters.path >>"
 
+        # Define Tag Fetch args
+        if [ -n "$CIRCLE_TAG" ]
+        then
+          # only tags operation have default --tags. others will no tag options
+          tag_args="--tags"
+        fi
+        if [ << parameters.without_tags >> == 'true']
+        then
+          tag_args="--no-tags"
+        fi
+
         # Fetch remote and check the commit ID of the checked out code
         if [ -n "$CIRCLE_TAG" ]
         then
           # tag
-          git fetch --tags --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
+          git fetch ${tag_args} --depth << parameters.fetch_depth >> --force origin "refs/tags/${CIRCLE_TAG}"
         elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+$  ]]`
         then
           # pull request
-          git fetch --depth << parameters.fetch_depth >> --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
+          git fetch ${tag_args} --depth << parameters.fetch_depth >> --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
         else
           # others
-          git fetch --depth=<< parameters.fetch_depth >> --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+          git fetch ${tag_args} --depth=<< parameters.fetch_depth >> --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
         fi
 
         # Check the commit ID of the checked out code

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -90,7 +90,7 @@ steps:
           # only tags operation have default --tags. others will no tag options
           tag_args="--tags"
         fi
-        if [ << parameters.no_tags >> == 'true']
+        if [ '<< parameters.no_tags >>' == 'true' ]
         then
           tag_args="--no-tags"
         fi

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -12,14 +12,6 @@ parameters:
       Pass more number then depth when you want to check futher commit history.
     type: integer
     default: 10
-  without_tags:
-    description: >
-      true to add '--no-tags' when fetching.
-      As git not offer tag depth, we only able to control fetch all tags or not.
-      This enable you to stop fetch tags when you have vast numbers of tags during specified fetch depth.
-      In other word, if you need tag then fetch specified tags manually when use 'without_tag: true'.
-    type: boolean
-    default: false
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.
@@ -35,6 +27,14 @@ parameters:
       Checkout directory (default: job’s working_directory)
     type: string
     default: .
+  no_tags:
+    description: >
+      true to add '--no-tags' when fetching.
+      As git not offer tag depth, we only able to control fetch all tags or not.
+      This enable you to stop fetch tags when you have vast numbers of tags during specified fetch depth.
+      In other word, if you need tag then fetch specified tags manually when use 'without_tag: true'.
+    type: boolean
+    default: false
 steps:
   - run:
       name: Checkout code shallow
@@ -90,7 +90,7 @@ steps:
           # only tags operation have default --tags. others will no tag options
           tag_args="--tags"
         fi
-        if [ << parameters.without_tags >> == 'true']
+        if [ << parameters.no_tags >> == 'true']
         then
           tag_args="--no-tags"
         fi

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -13,11 +13,12 @@ parameters:
     description: >
       git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
       you don't need set '--force' option as it already set by default.
-      in case of tag, '-t' sat by default in tag_fetch_options.
+      in case of tag, add '--no-tags' on this option and tag_fetch_options.
   tag_fetch_options:
     type: string
     default: "--tags"
     description: >
+      This option apply when git operation is tag. Use 'fetch_options' instead if pr and other git operation.
       Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'.
       Default value is '--tags'
   keyscan_github:

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -1,6 +1,6 @@
 description: |
-    checkout by git shallow clone with git options. Support Alpine, Ubuntu, Debian and others.
-    eval is used in step, Fish shell is not supported.
+  checkout by git shallow clone with git options. Support Alpine, Ubuntu, Debian and others.
+  eval is used in step, Fish shell is not supported.
 parameters:
   clone_options:
     type: string
@@ -12,14 +12,14 @@ parameters:
     default: "--depth 10"
     description: >
       git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
-      you donot beed set '--force' option as it already set by default.
-      in case of tag, '-t' sat by default in tag_fetch_options
+      you don't need set '--force' option as it already set by default.
+      in case of tag, '-t' sat by default in tag_fetch_options.
   tag_fetch_options:
     type: string
     default: "--tags"
     description: >
       Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'.
-      Default value is --tags
+      Default value is '--tags'
   keyscan_github:
     description: >
       Pass `true` to dynamically get ssh-rsa from `github.com`.

--- a/src/examples/checkout.yml
+++ b/src/examples/checkout.yml
@@ -21,6 +21,9 @@ description: |
   # clone the repository to src
   - git-shallow-clone/checkout:
       path: src
+  # skip tag fetch on `PR`, `PUSH` and fetch only single tag on `TAG`
+  - git-shallow-clone/checkout:
+      no_tags: true
 
 usage:
   version: 2.1

--- a/src/examples/checkout_advanced.yml
+++ b/src/examples/checkout_advanced.yml
@@ -12,6 +12,13 @@ description: |
   # use --shallow-since for fetch timing, but not for clone timing.
   - git-shallow-clone/checkout_advanced
       fetch_options: '--shallow-since "5 days ago"'
+  # use --no-tags to skip tag fetch on `PR` and `PUSH`.
+  - git-shallow-clone/checkout_advanced
+      fetch_options: '--depth 10 --no-tags'
+  # use --no-tags to fetch single tag on git `TAG`.
+  - git-shallow-clone/checkout_advanced
+      fetch_options: '--depth 10 --no-tags' # you can omit this.
+      tag_fetch_options: '--no-tags'
 
 usage:
   version: 2.1


### PR DESCRIPTION
additional PR to release https://github.com/guitarrapc/git-shallow-clone-orb/pull/23

# tl;dr;

* added: `no_tags` parameter to `git-shallow-clone/checkout`.
* chore: add --no-tag example to `git-shallow-clone/checkout_advanced`.
* chore: add test for `no_tags` on CI.
* chore: add example to skip tag fetch.

## Summary

### checkout also need no_tags options.

add `no_tags: <boolean>` to handle --no-tags on checkout command.

```yaml
    steps:
      - git-shallow-clone/checkout:
          fetch_depth: 1000
          no_tags: true
```

### checkout_advanced need example

Only use `--no-tags` on tag_fetch_options will fetch all tags on pr or push.

```yaml
    steps:
      - git-shallow-clone/checkout_advanced:
          clone_options: "--depth 1"
          fetch_options: "--depth 1000"
          tag_fetch_options: "--no-tags"
      - run: git tag --list
```

```
# Fetch remote and check the commit ID of the checked out code
if [ -n "$CIRCLE_TAG" ]
then
  # tag
  git fetch --no-tags --depth 1000 --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
then
  # pull request
  git fetch --depth 1000 --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
else
  # others
  git fetch --depth 1000 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
fi
```

```
git tag --list
WARNING: terminal is not fully functional
-  (press RETURN)v0.1.0
v0.1.1
v0.1.2
v0.1.3
v0.2.0
v1.0.0
v1.0.1
v1.1.0
v1.1.1
v1.1.2
v1.2.0
v1.2.1
v1.2.2
v1.2.3
v2.0.0
v2.0.1
v2.0.2
v2.0.3
v2.1.0
v2.3.0
```

There are 2 choice to handle tag fetch on pr and push.

* Choise 1: Pull Request and other also automatically add `--no-tags` when tag_fetch_options was used?
* Choise 2: Or just add --no-tags on fetch_options.


Let's use Choise 2 for simpler usage.
To skip fetch tag on pr, and fetch single tag on tag operation "add `--no-tags` to both fetch_options and tag_fetch_options".

```yaml
    steps:
      - git-shallow-clone/checkout_advanced:
          clone_options: "--depth 1"
          fetch_options: "--depth 1000 --no-tags"
          tag_fetch_options: "--no-tags"
      - run: git tag --list
```

