### PR TITLE
feat: add integration test for submodule and .ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,18 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           path: src
+  integration-test-checkout_submodule:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - run: |
+          set -e
+          ls -l | wc -l
+          count=$(ls -l | wc -l)
+          if [ $count -eq 0 ]; then exit 1; fi
   integration-test-checkout_tags:
     docker:
       - image: cimg/base:stable
@@ -180,6 +192,7 @@ workflows:
       #- integration-test-checkout_macos
       - integration-test-checkout_notags
       - integration-test-checkout_path
+      - integration-test-checkout_submodule
       - integration-test-checkout_tags
 
       # Publish a semver version of the orb. relies on
@@ -207,6 +220,7 @@ workflows:
             #- integration-test-checkout_macos
             - integration-test-checkout_notags
             - integration-test-checkout_path
+            - integration-test-checkout_submodule
             - integration-test-checkout_tags
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,19 @@ parameters:
 
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  standard-checkout:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: "test .ssh is exists"
+          command: |
+            set -e
+            if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa" ]; then exit 1;fi # shold not be size 0
+            ls ${HOME}/.ssh -la
   integration-test-checkout:
     docker:
       - image: cimg/base:stable
@@ -31,9 +44,8 @@ jobs:
           command: |
             set -e
             if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
-            if [ ! -f "${HOME}/.ssh/known_hosts]; then exit 1;fi
-            if [ ! -f "${HOME}/.ssh/id_rsa]; then exit 1;fi
-            # if [ ! -f "${HOME}/.ssh/id_rsa.pub]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa" ]; then exit 1;fi # shold not be size 0
             ls ${HOME}/.ssh -la
   integration-test-checkout_advanced:
     docker:
@@ -45,9 +57,8 @@ jobs:
           command: |
             set -e
             if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
-            if [ ! -f "${HOME}/.ssh/known_hosts]; then exit 1;fi
-            if [ ! -f "${HOME}/.ssh/id_rsa]; then exit 1;fi
-            # if [ ! -f "${HOME}/.ssh/id_rsa.pub]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa" ]; then exit 1;fi # shold not be size 0
             ls ${HOME}/.ssh -la
   integration-test-checkout_advanced_fetchoptions:
     docker:
@@ -72,6 +83,19 @@ jobs:
             git tag --list
             count=$(git tag --list | wc -l)
             if [ $count -ne 0 ]; then exit 1; fi
+  integration-test-checkout_advanced_sshkey:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced
+      - run:
+          name: "test .ssh is exists"
+          command: |
+            set -e
+            if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa" ]; then exit 1;fi # shold not be size 0
+            ls ${HOME}/.ssh -la
   integration-test-checkout_advanced_submodule:
     docker:
       - image: cimg/base:stable
@@ -158,6 +182,19 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           path: src
+  integration-test-checkout_sshkey:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout
+      - run:
+          name: "test .ssh is exists"
+          command: |
+            set -e
+            if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa" ]; then exit 1;fi # shold not be size 0
+            ls ${HOME}/.ssh -la
   integration-test-checkout_submodule:
     docker:
       - image: cimg/base:stable
@@ -223,6 +260,7 @@ workflows:
       - integration-test-checkout_advanced
       - integration-test-checkout_advanced_fetchoptions
       - integration-test-checkout_advanced_notags
+      - integration-test-checkout_advanced_sshkey
       - integration-test-checkout_advanced_submodule
       - integration-test-checkout_advanced_tags
       - integration-test-checkout_alpine
@@ -233,8 +271,10 @@ workflows:
       #- integration-test-checkout_macos
       - integration-test-checkout_notags
       - integration-test-checkout_path
+      - integration-test-checkout_sshkey
       - integration-test-checkout_submodule
       - integration-test-checkout_tags
+      - standard-checkout
 
       # Publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -252,6 +292,7 @@ workflows:
             - integration-test-checkout_advanced
             - integration-test-checkout_advanced_fetchoptions
             - integration-test-checkout_advanced_notags
+            - integration-test-checkout_advanced_sshkey
             - integration-test-checkout_advanced_submodule
             - integration-test-checkout_advanced_tags
             - integration-test-checkout_alpine
@@ -262,8 +303,10 @@ workflows:
             #- integration-test-checkout_macos
             - integration-test-checkout_notags
             - integration-test-checkout_path
+            - integration-test-checkout_sshkey
             - integration-test-checkout_submodule
             - integration-test-checkout_tags
+            - standard-checkout
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,13 @@ jobs:
           fetch_options: "--depth 1000 --no-tags"
           tag_fetch_options: "--no-tags"
       # should be no tags
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -ne 0 ]; then exit 1; fi
+      - run:
+          name: "test single tag is fetched"
+          command: |
+            set -e
+            git tag --list
+            count=$(git tag --list | wc -l)
+            if [ $count -ne 0 ]; then exit 1; fi
   integration-test-checkout_advanced_submodule:
     docker:
       - image: cimg/base:stable
@@ -74,11 +76,13 @@ jobs:
           clone_options: "--depth 1"
           fetch_options: "--depth 1000"
       # should be all tags in fetch depth
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -eq 0 ]; then exit 1; fi
+      - run:
+          name: "test many tags is fetched"
+          command: |
+            set -e
+            git tag --list
+            count=$(git tag --list | wc -l)
+            if [ $count -eq 0 ]; then exit 1; fi
   integration-test-checkout_alpine:
     docker:
       - image: circleci/redis:alpine3.13
@@ -123,11 +127,13 @@ jobs:
           fetch_depth: 1000
           no_tags: true
       # should be no tags
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -ne 0 ]; then exit 1; fi
+      - run:
+          name: "test single tag is fetched"
+          command: |
+            set -e
+            git tag --list
+            count=$(git tag --list | wc -l)
+            if [ $count -ne 0 ]; then exit 1; fi
   integration-test-checkout_path:
     docker:
       - image: cimg/base:stable
@@ -141,11 +147,13 @@ jobs:
       - git-shallow-clone/checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: |
-          set -e
-          ls -l | wc -l
-          count=$(ls -l | wc -l)
-          if [ $count -eq 0 ]; then exit 1; fi
+      - run:
+          name: "test submodule is successfully init"
+          command: |
+            set -e
+            ls -l | wc -l
+            count=$(ls -l | wc -l)
+            if [ $count -eq 0 ]; then exit 1; fi
   integration-test-checkout_tags:
     docker:
       - image: cimg/base:stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,29 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout
+      - run:
+          name: "test .ssh is exists"
+          command: |
+            set -e
+            if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa]; then exit 1;fi
+            # if [ ! -f "${HOME}/.ssh/id_rsa.pub]; then exit 1;fi
+            ls ${HOME}/.ssh -la
   integration-test-checkout_advanced:
     docker:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout_advanced
+      - run:
+          name: "test .ssh is exists"
+          command: |
+            set -e
+            if [ ! -d "${HOME}/.ssh" ]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/known_hosts]; then exit 1;fi
+            if [ ! -f "${HOME}/.ssh/id_rsa]; then exit 1;fi
+            # if [ ! -f "${HOME}/.ssh/id_rsa.pub]; then exit 1;fi
+            ls ${HOME}/.ssh -la
   integration-test-checkout_advanced_fetchoptions:
     docker:
       - image: cimg/base:stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,20 @@ jobs:
           git tag --list
           count=$(git tag --list | wc -l)
           if [ $count -ne 0 ]; then exit 1; fi
+  integration-test-checkout_advanced_submodule:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced
+      - run: git submodule sync
+      - run: git submodule update --init
+      - run:
+          name: "test submodule is successfully init"
+          command: |
+            set -e
+            ls -l | wc -l
+            count=$(ls -l | wc -l)
+            if [ $count -eq 0 ]; then exit 1; fi
   integration-test-checkout_advanced_tags:
     docker:
       - image: cimg/base:stable
@@ -183,6 +197,7 @@ workflows:
       - integration-test-checkout_advanced
       - integration-test-checkout_advanced_fetchoptions
       - integration-test-checkout_advanced_notags
+      - integration-test-checkout_advanced_submodule
       - integration-test-checkout_advanced_tags
       - integration-test-checkout_alpine
       - integration-test-checkout_depth
@@ -211,6 +226,7 @@ workflows:
             - integration-test-checkout_advanced
             - integration-test-checkout_advanced_fetchoptions
             - integration-test-checkout_advanced_notags
+            - integration-test-checkout_advanced_submodule
             - integration-test-checkout_advanced_tags
             - integration-test-checkout_alpine
             - integration-test-checkout_depth

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "empty-repo-submodule"]
+	path = empty-repo-submodule
+	url = https://github.com/guitarrapc/empty-repo-submodule


### PR DESCRIPTION
## tl;dr;

add integration test for submodule and ssh

* normal submodule checkout (checkout -> git submodule sync & upgrade --init
* check .ssh and seriese is exists.

## Help wanted

There's no way to retrieve `$CHECKOUT_KEY`. CircleCI standard `checkout` can do it, but 3rd party are lock out from this feature.