### PR TITLE
feat: use circleci orb init template for CI and others.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.5
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@dev:alpha
+  git-shallow-clone: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@10.0.5
 
 # Pipeline Parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,215 +1,35 @@
 version: 2.1
-
+setup: true
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@10.0.5
+  orb-tools: circleci/orb-tools@11.1
+  shellcheck: circleci/shellcheck@3.1
 
-# Pipeline Parameters
-## These parameters are used internally by orb-tools. Skip to the Jobs section.
-parameters:
-  run-integration-tests:
-    description: An internal flag to prevent integration test from running before a development version has been created.
-    type: boolean
-    default: false
-  dev-orb-version:
-    description: >
-      The development version of the orb to test.
-      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
-      A "dev:alpha" version must exist for the initial pipeline run.
-    type: string
-    default: "dev:alpha"
-
-jobs:
-  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
-  integration-test-checkout:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout
-  integration-test-checkout_advanced:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout_advanced
-  integration-test-checkout_advanced_fetchoptions:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--shallow-since "5 days ago"'
-          fetch_options: '--shallow-since "5 days ago"'
-  integration-test-checkout_advanced_notags:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: "--depth 1"
-          fetch_options: "--depth 1000 --no-tags"
-          tag_fetch_options: "--no-tags"
-      # should be no tags
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -ne 0 ]; then exit 1; fi
-  integration-test-checkout_advanced_tags:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: "--depth 1"
-          fetch_options: "--depth 1000"
-      # should be all tags in fetch depth
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -eq 0 ]; then exit 1; fi
-  integration-test-checkout_alpine:
-    docker:
-      - image: circleci/redis:alpine3.13
-    steps:
-      - run: apk update && apk add openssh git # openssh is required
-      - git-shallow-clone/checkout
-  integration-test-checkout_depth:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          depth: 5
-          fetch_depth: 10
-  integration-test-checkout_fetchdepth:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          fetch_depth: 1
-  integration-test-checkout_keyscan_bitbucket:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          keyscan_bitbucket: true
-  integration-test-checkout_keyscan_github:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          keyscan_github: true
-  integration-test-checkout_macos:
-    macos:
-      xcode: 13.0.0
-    steps:
-      - git-shallow-clone/checkout
-  integration-test-checkout_notags:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          fetch_depth: 1000
-          no_tags: true
-      # should be no tags
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -ne 0 ]; then exit 1; fi
-  integration-test-checkout_path:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          path: src
-  integration-test-checkout_tags:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - git-shallow-clone/checkout:
-          fetch_depth: 1000
-      # should be all tags in fetch depth
-      - run: |
-          set -e
-          git tag --list
-          count=$(git tag --list | wc -l)
-          if [ $count -eq 0 ]; then exit 1; fi
+filters: &filters
+  tags:
+    only: /.*/
 
 workflows:
-  # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
-  # This workflow will run on every commit
-  test-pack:
-    unless: << pipeline.parameters.run-integration-tests >>
+  lint-pack:
     jobs:
-      - orb-tools/lint
-      - orb-tools/pack
-      - orb-tools/publish-dev:
+      - orb-tools/lint:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/review:
+          filters: *filters
+      - shellcheck/check:
+          filters: *filters
+      - orb-tools/publish:
           orb-name: guitarrapc/git-shallow-clone
+          vcs-type: << pipeline.project.type >>
           requires:
-            - orb-tools/lint
-            - orb-tools/pack
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              # Forked pull requests not allowed to publish alpha release, so just skip it.
-              ignore: /pull\/[0-9]+/
-      - orb-tools/trigger-integration-tests-workflow:
-          name: trigger-integration-dev
-          requires:
-            - orb-tools/publish-dev
-
-  # This `integration-test_deploy` workflow will only run
-  # when the run-integration-tests pipeline parameter is set to true.
-  # It is meant to be triggered by the "trigger-integration-tests-workflow"
-  # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-test_deploy:
-    when: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      # your integration test jobs go here: essentially, run all your orb's
-      # jobs and commands to ensure they behave as expected. or, run other
-      # integration tests of your choosing
-      # Run any integration tests defined within the `jobs` key.
-      - integration-test-checkout
-      - integration-test-checkout_advanced
-      - integration-test-checkout_advanced_fetchoptions
-      - integration-test-checkout_advanced_notags
-      - integration-test-checkout_advanced_tags
-      - integration-test-checkout_alpine
-      - integration-test-checkout_depth
-      - integration-test-checkout_fetchdepth
-      - integration-test-checkout_keyscan_bitbucket
-      - integration-test-checkout_keyscan_github
-      #- integration-test-checkout_macos
-      - integration-test-checkout_notags
-      - integration-test-checkout_path
-      - integration-test-checkout_tags
-
-      # Publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major|skip]"
-      # as that will determine whether a patch, minor or major
-      # version will be published or if publishing should
-      # be skipped.
-      # e.g. [semver:patch] will cause a patch version to be published.
-      - orb-tools/dev-promote-prod-from-commit-subject:
-          orb-name: guitarrapc/git-shallow-clone
-          add-pr-comment: false
-          fail-if-semver-not-indicated: false
-          publish-version-tag: true
-          requires:
-            - integration-test-checkout
-            - integration-test-checkout_advanced
-            - integration-test-checkout_advanced_fetchoptions
-            - integration-test-checkout_advanced_notags
-            - integration-test-checkout_advanced_tags
-            - integration-test-checkout_alpine
-            - integration-test-checkout_depth
-            - integration-test-checkout_fetchdepth
-            - integration-test-checkout_keyscan_bitbucket
-            - integration-test-checkout_keyscan_github
-            #- integration-test-checkout_macos
-            - integration-test-checkout_notags
-            - integration-test-checkout_path
-            - integration-test-checkout_tags
-          filters:
-            branches:
-              only:
-                - master
-                - main
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+          # Use a context to hold your publishing token.
+          context: orb-publisher
+          filters: *filters
+      # Triggers the next workflow in the Orb Development Kit.
+      - orb-tools/continue:
+          pipeline-number: << pipeline.number >>
+          vcs-type: << pipeline.project.type >>
+          requires: [orb-tools/publish]
+          filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
+          max_command_length: 10000
           filters: *filters
       - shellcheck/check:
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -120,6 +120,18 @@ jobs:
           git tag --list
           count=$(git tag --list | wc -l)
           if [ $count -eq 0 ]; then exit 1; fi
+  integration-test-api-dispatch:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run: |
+          set -e
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/guitarrapc/git-shallow-clone-test/pipeline" \
+          -H "Content-Type: application/json" \
+          -H "Circle-Token: $CIRCLECI_API_TOKEN" \
+          -d '{
+              "branch": "pull/2/head"
+              }'
 workflows:
   test-deploy:
     jobs:
@@ -156,6 +168,9 @@ workflows:
           filters: *filters
       - integration-test-checkout_tags:
           filters: *filters
+      - integration-test-api-dispatch:
+          filters: *filters
+          context: api
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   <orb-name>: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.5
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,0 +1,186 @@
+version: 2.1
+orbs:
+  <orb-name>: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
+  orb-tools: circleci/orb-tools@11.1
+
+filters: &filters
+  tags:
+    only: /.*/
+
+jobs:
+  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  integration-test-checkout:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout
+  integration-test-checkout_advanced:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced
+  integration-test-checkout_advanced_fetchoptions:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: '--shallow-since "5 days ago"'
+          fetch_options: '--shallow-since "5 days ago"'
+  integration-test-checkout_advanced_notags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: "--depth 1"
+          fetch_options: "--depth 1000 --no-tags"
+          tag_fetch_options: "--no-tags"
+      # should be no tags
+      - run: |
+          set -e
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ $count -ne 0 ]; then exit 1; fi
+  integration-test-checkout_advanced_tags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: "--depth 1"
+          fetch_options: "--depth 1000"
+      # should be all tags in fetch depth
+      - run: |
+          set -e
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ $count -eq 0 ]; then exit 1; fi
+  integration-test-checkout_alpine:
+    docker:
+      - image: circleci/redis:alpine3.13
+    steps:
+      - run: apk update && apk add openssh git # openssh is required
+      - git-shallow-clone/checkout
+  integration-test-checkout_depth:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          depth: 5
+          fetch_depth: 10
+  integration-test-checkout_fetchdepth:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          fetch_depth: 1
+  integration-test-checkout_keyscan_bitbucket:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          keyscan_bitbucket: true
+  integration-test-checkout_keyscan_github:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          keyscan_github: true
+  integration-test-checkout_macos:
+    macos:
+      xcode: 13.0.0
+    steps:
+      - git-shallow-clone/checkout
+  integration-test-checkout_notags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          fetch_depth: 1000
+          no_tags: true
+      # should be no tags
+      - run: |
+          set -e
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ $count -ne 0 ]; then exit 1; fi
+  integration-test-checkout_path:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          path: src
+  integration-test-checkout_tags:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - git-shallow-clone/checkout:
+          fetch_depth: 1000
+      # should be all tags in fetch depth
+      - run: |
+          set -e
+          git tag --list
+          count=$(git tag --list | wc -l)
+          if [ $count -eq 0 ]; then exit 1; fi
+workflows:
+  test-deploy:
+    jobs:
+      # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      # your integration test jobs go here: essentially, run all your orb's
+      # jobs and commands to ensure they behave as expected. or, run other
+      # integration tests of your choosing
+      # Run any integration tests defined within the `jobs` key.
+      - integration-test-checkout:
+          filters: *filters
+      - integration-test-checkout_advanced:
+          filters: *filters
+      - integration-test-checkout_advanced_fetchoptions:
+          filters: *filters
+      - integration-test-checkout_advanced_notags:
+          filters: *filters
+      - integration-test-checkout_advanced_tags:
+          filters: *filters
+      - integration-test-checkout_alpine:
+          filters: *filters
+      - integration-test-checkout_depth:
+          filters: *filters
+      - integration-test-checkout_fetchdepth:
+          filters: *filters
+      - integration-test-checkout_keyscan_bitbucket:
+          filters: *filters
+      - integration-test-checkout_keyscan_github:
+          filters: *filters
+      # - integration-test-checkout_macos:
+      #     filters: *filters
+      - integration-test-checkout_notags:
+          filters: *filters
+      - integration-test-checkout_path:
+          filters: *filters
+      - integration-test-checkout_tags:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: guitarrapc/git-shallow-clone
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - integration-test-checkout
+            - integration-test-checkout_advanced
+            - integration-test-checkout_advanced_fetchoptions
+            - integration-test-checkout_advanced_notags
+            - integration-test-checkout_advanced_tags
+            - integration-test-checkout_alpine
+            - integration-test-checkout_depth
+            - integration-test-checkout_fetchdepth
+            - integration-test-checkout_keyscan_bitbucket
+            - integration-test-checkout_keyscan_github
+            #- integration-test-checkout_macos
+            - integration-test-checkout_notags
+            - integration-test-checkout_path
+            - integration-test-checkout_tags
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  <orb-name>: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
+  git-shallow-clone: guitarrapc/git-shallow-clone@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@11.5
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,8 +24,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout_advanced:
-          clone_options: '--shallow-since "5 days ago"'
-          fetch_options: '--shallow-since "5 days ago"'
+          clone_options: '--shallow-since "2 years ago"'
+          fetch_options: '--shallow-since "2 years ago"'
   integration-test-checkout_advanced_notags:
     docker:
       - image: cimg/base:stable

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,0 +1,41 @@
+name: "\U0001F41E  Bug Report"
+description: Report any identified bugs.
+title: "Bug: "
+labels: [bug]
+# assignees: ''
+body:
+  - type: checkboxes
+    attributes:
+      label: "Is there an existing issue for this?"
+      description: "Please search [here](https://github.com/<organization>/<project-name>/issues?q=is%3Aissue) to see if an issue already exists for the bug you encountered"
+      options:
+        - label: "I have searched the existing issues"
+          required: true
+
+  - type: input
+    attributes:
+      label: "Orb version"
+      description: |
+        Which version of `guitarrapc/git-shallow-clone` are you using?
+      placeholder: "1.0.0"
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: "Current behavior"
+      description: "How does the issue manifest?"
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: "Minimum reproduction config"
+      description: "Enter a URL to a failed build or write a config example to reproduce the issue"
+      placeholder: "https://app.circleci.com/..."
+
+  - type: textarea
+    attributes:
+      label: "Other"
+      description: |
+        Anything else you want to share?

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,34 @@
+name: "\U0001F4A1 Feature Request"
+description: Have an idea for a new feature? Begin by submitting a Feature Request
+title: 'Request: '
+labels: [enhancement]
+# assignees: ''
+body:
+  - type: checkboxes
+    attributes:
+      label: "Is there an existing issue that is already proposing this?"
+      description: "Please search [here](https://github.com/CircleCI-Public/circleci-config-sdk-ts/issues?q=is%3Aissue) to see if an issue already exists for the feature you are requesting"
+      options:
+      - label: "I have searched the existing issues"
+        required: true
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: "Describe the problem imposed by not having this feature"
+      description: "Please describe the use-case you are attempting to implement, and the current limitations you are facing."
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: "Describe the solution you'd like"
+      description: "A clear and concise description of what you want to happen. Add any considered drawbacks"
+
+
+  - type: textarea
+    attributes:
+      label: "Other"
+      description: |
+        Anything else you want to share?

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST.md
@@ -1,0 +1,25 @@
+## PR Type
+What kind of change does this PR introduce?
+
+<!-- Please check the one that applies to this PR using "x". -->
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting)
+- [ ] Refactoring (no functional changes)
+- [ ] CI related changes
+- [ ] Other... Please describe:
+
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+Issue Number: N/A
+
+## What is the new behavior?
+
+## Does this PR introduce a breaking change?
+- [ ] Yes
+- [ ] No
+
+<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
+
+## Other information

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# orb.yml is "packed" from source, and not published directly from the repository.
+orb.yml
+.DS_Store

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+extends: relaxed
+
+rules:
+    line-length:
+        max: 200
+        allow-non-breakable-inline-mappings: true
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## git-shallow-clone-orb
 [![CircleCI](https://circleci.com/gh/guitarrapc/git-shallow-clone-orb.svg?style=svg)](https://circleci.com/gh/guitarrapc/git-shallow-clone-orb) ![Orb Version Badge](https://badges.circleci.com/orbs/guitarrapc/git-shallow-clone.svg)
 
+
 ## Usage
 
 See the [orb registry listing](http://circleci.com/orbs/registry/orb/guitarrapc/git-shallow-clone) for usage guidelines.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
-description: |
-  Orb to provide git shallow clone.
+description: >
+  Provides git shallow clone instead of full clone.
   Supporting trigger for tag, pull_request and push, works on Alpine, Debian, Ubuntu, macOS.
 
   Provied commands:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,20 +1,15 @@
 version: 2.1
 
 description: |
-  Shallow clone on CircleCI, support tag, pr and other.
+  Orb to provide git shallow clone.
+  Supporting trigger for tag, pull_request and push, works on Alpine, Debian, Ubuntu, macOS.
+
+  Provied commands:
+  - checkout
+  - checkout_advanced
+
+  requirement: git
 
 # This information will be displayed in the orb registry and is not mandatory.
 display:
   source_url: https://github.com/guitarrapc/git-shallow-clone-orb
-## Requirements ##
-## - git
-
-## Work on
-## - [x] Alpine (apk add git)
-## - [x] Debian Strech
-## - [x] Ubuntu
-## - [x] macOS
-
-## Commands
-## - checkout
-## - checkout_advanced

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,26 @@
+# Orb Source
+
+Orbs are shipped as individual `orb.yml` files, however, to make development easier, it is possible to author an orb in _unpacked_ form, which can be _packed_ with the CircleCI CLI and published.
+
+The default `.circleci/config.yml` file contains the configuration code needed to automatically pack, test, and deploy any changes made to the contents of the orb source in this directory.
+
+## @orb.yml
+
+This is the entry point for our orb "tree", which becomes our `orb.yml` file later.
+
+Within the `@orb.yml` we generally specify 4 configuration keys
+
+**Keys**
+
+1. **version**
+    Specify version 2.1 for orb-compatible configuration `version: 2.1`
+2. **description**
+    Give your orb a description. Shown within the CLI and orb registry
+3. **display**
+    Specify the `home_url` referencing documentation or product URL, and `source_url` linking to the orb's source repository.
+4. **orbs**
+    (optional) Some orbs may depend on other orbs. Import them here.
+
+## See:
+ - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
+ - [Reusable Configuration](https://circleci.com/docs/2.0/reusing-config)

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -1,4 +1,6 @@
-description: checkout by git shallow clone. Support Alpine, Ubuntu, Debian and others.
+description: >
+  Provides git shallow clone instead of full clone.
+  This command is for simple usage when you don't need options for clone, fetch and tag fetch.
 parameters:
   depth:
     description: >
@@ -32,7 +34,7 @@ parameters:
     default: false
   path:
     description: >
-      Checkout directory (default: job’s working_directory)
+      Checkout directory (default: job working_directory)
     type: string
     default: .
 steps:

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -1,6 +1,7 @@
-description: |
-  checkout by git shallow clone with git options. Support Alpine, Ubuntu, Debian and others.
-  eval is used in step, Fish shell is not supported.
+description: >
+  Provides git shallow clone instead of full clone.
+  This command is for advaned usage when you need options for clone, fetch and tag fetch.
+  eval is used in step and Fish shell is not supported.
 parameters:
   clone_options:
     type: string
@@ -33,7 +34,7 @@ parameters:
     default: false
   path:
     description: >
-      Checkout directory (default: job’s working_directory)
+      Checkout directory (default: job working_directory)
     type: string
     default: .
 steps:

--- a/src/examples/checkout.yml
+++ b/src/examples/checkout.yml
@@ -27,10 +27,8 @@ description: |
 
 usage:
   version: 2.1
-
   orbs:
     git-shallow-clone: guitarrapc/git-shallow-clone@x.y.z
-
   workflows:
     build:
       jobs:

--- a/src/examples/checkout_advanced.yml
+++ b/src/examples/checkout_advanced.yml
@@ -22,10 +22,8 @@ description: |
 
 usage:
   version: 2.1
-
   orbs:
     git-shallow-clone: guitarrapc/git-shallow-clone@x.y.z
-
   workflows:
     build:
       jobs:


### PR DESCRIPTION
## tl;dr;

circleci orb instroduced with new template.

> https://circleci.com/docs/ja/orb-author/

This PR enables repository to convert to new CI/CD style and other capabilities `circleci orb init` provides.

## Summary

Biggest change is spliting config.yml and test-deploy.yml.
This enables developer to split orb pack process and test process.

Further more, now I don't need think about orb dev pack `orb-name:dev@alpha` on test-deploy initialization.
This means even orb dev was stopped for a while, I can re-begin development without additional effort.