### PR TITLE
update logic of checking whether branch is pull request

### DIFF
--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -112,7 +112,7 @@ steps:
         if [ -n "$CIRCLE_TAG" ]; then
           # tag
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
-        elif [[ $(echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$) ]]; then
+        elif [[ $(echo $CIRCLE_PULL_REQUEST | grep -E "${CIRCLE_BRANCH}$") ]]; then
           # pull request
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
         else


### PR DESCRIPTION
There is a possiblity that user create a PR with the branch name in the format of pull request format. Checking the env var CIRCLE_PULL_REQUEST instead.