### PR TITLE
fix: pullrequest api dispatch use `pull/NNN/head` not `pull/NNN`

### DIFF
--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -131,7 +131,7 @@ steps:
         echo 'Fetching from remote repository'
         if [ -n "$CIRCLE_TAG" ]; then
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force --tags origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
-        elif echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+$ > /dev/null; then
+        elif echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+/head$ > /dev/null; then
           # pull request called from api. see detail for https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin "+refs/${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
         else

--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -132,8 +132,8 @@ steps:
         if [ -n "$CIRCLE_TAG" ]; then
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force --tags origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
         elif echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+/head$ > /dev/null; then
-          # pull request called from api. see detail for https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
-          git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin "+refs/${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
+          # pull request called from api. Input should be `pull/123/head` see detail for https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
+          git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin "+refs/${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}"
         else
           git fetch ${fetch_tag_args} --depth << parameters.fetch_depth >> --force origin +refs/heads/${CIRCLE_BRANCH}:refs/remotes/origin/${CIRCLE_BRANCH}
         fi

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -117,6 +117,9 @@ steps:
         echo 'Fetching from remote repository'
         if [ -n "$CIRCLE_TAG" ]; then
           git fetch << parameters.tag_fetch_options >> << parameters.fetch_options >> --force --tags origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+        elif echo $CIRCLE_BRANCH | grep -E ^pull\/[0-9]+/head$ > /dev/null; then
+          # pull request called from api. Input should be `pull/123/head` see detail for https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
+          git fetch << parameters.tag_fetch_options >> << parameters.fetch_options >> --force origin "+refs/${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}"
         else
           git fetch << parameters.fetch_options >> --force origin +refs/heads/${CIRCLE_BRANCH}:refs/remotes/origin/${CIRCLE_BRANCH}
         fi


### PR DESCRIPTION
follow up: https://github.com/guitarrapc/git-shallow-clone-orb/pull/55

Confirm fixed https://app.circleci.com/pipelines/github/guitarrapc/git-shallow-clone-test/93/workflows/d5a6ba0a-e92d-48d9-a1a3-a4ffd532771a

![image](https://github.com/guitarrapc/git-shallow-clone-orb/assets/3856350/dc6a7f1e-5207-406f-87e1-9b87547ffdf2)
