### PR TITLE
fix: default parameter document of path

### DIFF
--- a/src/commands/checkout.yml
+++ b/src/commands/checkout.yml
@@ -34,7 +34,7 @@ parameters:
     default: false
   path:
     description: >
-      Checkout directory (default: job working_directory)
+      Checkout directory (default: `~/project`)
     type: string
     default: .
 steps:

--- a/src/commands/checkout_advanced.yml
+++ b/src/commands/checkout_advanced.yml
@@ -34,7 +34,7 @@ parameters:
     default: false
   path:
     description: >
-      Checkout directory (default: job working_directory)
+      Checkout directory (default: `~/project`)
     type: string
     default: .
 steps:


### PR DESCRIPTION
document update for https://circleci.com/developer/orbs/orb/guitarrapc/git-shallow-clone#commands
`path` default parameter is changed since v2.7.0